### PR TITLE
fixed a bug due to a reference to a non-existent variable

### DIFF
--- a/public/src/jquery.aljs-notification.js
+++ b/public/src/jquery.aljs-notification.js
@@ -28,10 +28,10 @@ if (typeof jQuery.aljs === "undefined") { throw new Error("Please include the AL
                 } else {
                     if (options === 'show' || (options === 'toggle' && $node.hasClass('slds-hide'))) {
                         $node.removeClass('slds-hide');
-                        $notification.trigger('dismissed.aljs.notification'); // Custom aljs event
+                        $node.trigger('dismissed.aljs.notification'); // Custom aljs event
                     } else if (options === 'dismiss' || (options === 'toggle' && !($node.hasClass('slds-hide')))) {
                         $node.addClass('slds-hide');
-                        $notification.trigger('shown.aljs.notification'); // Custom aljs event
+                        $node.trigger('shown.aljs.notification'); // Custom aljs event
                     }
                 }
             }); 


### PR DESCRIPTION
This fixes the "Uncaught ReferenceError: $notification is not defined" error that pops up when trying to show/hide a notification
